### PR TITLE
Fix multi-instance bug

### DIFF
--- a/xwinwrap.c
+++ b/xwinwrap.c
@@ -489,7 +489,7 @@ int main(int argc, char **argv)
             flags |= CWBackPixel;
         }
 
-        window.window = XCreateWindow(display, window.desktop, window.x,
+        window.window = XCreateWindow(display, window.root, window.x,
                                       window.y, window.width, window.height, 0, depth, InputOutput, visual,
                                       flags, &attrs);
         XLowerWindow(display, window.window);


### PR DESCRIPTION
Change the parent window to root to fix a bug when multiple instance of xwinwrap are running.

How to reproduce the said bug:
Run 2 instances of xwinwrap then kill the first one, the second instance will crash as a result.